### PR TITLE
Fix clone URL (README: Use Google Colab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ python app.py
 To use with Google Colab, please use the following command:
 
 ```
-!git clone https://github.com/staoxiao/OmniGen.git
+!git clone https://github.com/VectorSpaceLab/OmniGen.git
 %cd OmniGen
 !pip install -e .
 !pip install gradio spaces


### PR DESCRIPTION
Hello!

Previously, [I wrote the section in the README related to Google Colab](https://github.com/staoxiao/OmniGen/pull/10), and at the time, the clone URL was `https://github.com/staoxiao/OmniGen.git`. Therefore, the instructions were based on that URL.

Since the clone URL has now been updated to `https://github.com/VectorSpaceLab/OmniGen.git`, I have modified the Google Colab instructions in the README accordingly.

I have also verified that the updated instructions work correctly on Google Colab without any issues.

Please review the changes at your earliest convenience.

## 