### PR TITLE
Adds support for 4bit (nf4) and 8bit bitsandbytes quantization (3/3)

### DIFF
--- a/OmniGen/model.py
+++ b/OmniGen/model.py
@@ -1,5 +1,6 @@
 # The code is revised from DiT
 import os
+import gc
 import torch
 import torch.nn as nn
 import numpy as np
@@ -10,6 +11,7 @@ from diffusers.loaders import PeftAdapterMixin
 from timm.models.vision_transformer import PatchEmbed, Attention, Mlp
 from huggingface_hub import snapshot_download
 from safetensors.torch import load_file
+from accelerate import init_empty_weights
 
 from OmniGen.transformer import Phi3Config, Phi3Transformer
 
@@ -187,20 +189,37 @@ class OmniGen(nn.Module, PeftAdapterMixin):
         self.llm.config.use_cache = False
     
     @classmethod
-    def from_pretrained(cls, model_name):
+    def from_pretrained(cls, model_name: str|os.PathLike, dtype: torch.dtype = torch.bfloat16, device: str|torch.device='cuda', low_cpu_mem_usage: bool = True,):
         if not os.path.exists(model_name):
             cache_folder = os.getenv('HF_HUB_CACHE')
             model_name = snapshot_download(repo_id=model_name,
                                            cache_dir=cache_folder,
                                            ignore_patterns=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'])
-        config = Phi3Config.from_pretrained(model_name)
-        model = cls(config)
-        if os.path.exists(os.path.join(model_name, 'model.safetensors')):
-            print("Loading safetensors")
-            ckpt = load_file(os.path.join(model_name, 'model.safetensors'))
+        
+        model_path = os.path.join(model_name, 'model.safetensors')
+        if not os.path.exists(model_path):
+            model_path = os.path.join(model_name, 'model.pt')
+            ckpt = torch.load(model_path, map_location='cpu')
         else:
-            ckpt = torch.load(os.path.join(model_name, 'model.pt'), map_location='cpu')
-        model.load_state_dict(ckpt)
+            print("Loading safetensors")
+            ckpt = load_file(model_path, 'cpu')
+
+        if low_cpu_mem_usage:
+            with init_empty_weights():
+                config = Phi3Config.from_pretrained(model_name)
+                model = cls(config)
+        
+            model.load_state_dict(ckpt, assign=True)
+            model = model.to(device, dtype)
+        else:
+            config = Phi3Config.from_pretrained(model_name)
+            model = cls(config)
+            model.load_state_dict(ckpt)
+            model = model.to(device, dtype)
+        
+        del ckpt
+        torch.cuda.empty_cache()
+        gc.collect()
         return model
 
     def initialize_weights(self):

--- a/OmniGen/model.py
+++ b/OmniGen/model.py
@@ -189,7 +189,7 @@ class OmniGen(nn.Module, PeftAdapterMixin):
         self.llm.config.use_cache = False
     
     @classmethod
-    def from_pretrained(cls, model_name: str|os.PathLike, dtype: torch.dtype = torch.bfloat16, device: str|torch.device='cuda', low_cpu_mem_usage: bool = True,):
+    def from_pretrained(cls, model_name: str|os.PathLike, dtype: torch.dtype = torch.bfloat16, low_cpu_mem_usage: bool = True,):
         if not os.path.exists(model_name):
             cache_folder = os.getenv('HF_HUB_CACHE')
             model_name = snapshot_download(repo_id=model_name,
@@ -210,12 +210,12 @@ class OmniGen(nn.Module, PeftAdapterMixin):
                 model = cls(config)
         
             model.load_state_dict(ckpt, assign=True)
-            model = model.to(device, dtype)
+            model = model.to(dtype)
         else:
             config = Phi3Config.from_pretrained(model_name)
             model = cls(config)
             model.load_state_dict(ckpt)
-            model = model.to(device, dtype)
+            model = model.to(dtype)
         
         del ckpt
         torch.cuda.empty_cache()

--- a/OmniGen/model.py
+++ b/OmniGen/model.py
@@ -12,9 +12,10 @@ from timm.models.vision_transformer import PatchEmbed, Attention, Mlp
 from huggingface_hub import snapshot_download
 from safetensors.torch import load_file
 from accelerate import init_empty_weights
+from transformers import BitsAndBytesConfig
 
 from OmniGen.transformer import Phi3Config, Phi3Transformer
-
+from OmniGen.utils import quantize_bnb
 
 def modulate(x, shift, scale):
     return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
@@ -187,9 +188,13 @@ class OmniGen(nn.Module, PeftAdapterMixin):
 
         self.llm = Phi3Transformer(config=transformer_config)
         self.llm.config.use_cache = False
+
+        # bnb 4bit quantized models cannot be offloaded
+        self.offloadable = True
+        self.quantization_config = None
     
     @classmethod
-    def from_pretrained(cls, model_name: str|os.PathLike, dtype: torch.dtype = torch.bfloat16, low_cpu_mem_usage: bool = True,):
+    def from_pretrained(cls, model_name: str|os.PathLike, dtype: torch.dtype = torch.bfloat16, quantization_config: BitsAndBytesConfig = None, low_cpu_mem_usage: bool = True,):
         if not os.path.exists(model_name):
             cache_folder = os.getenv('HF_HUB_CACHE')
             model_name = snapshot_download(repo_id=model_name,
@@ -201,22 +206,30 @@ class OmniGen(nn.Module, PeftAdapterMixin):
             model_path = os.path.join(model_name, 'model.pt')
             ckpt = torch.load(model_path, map_location='cpu')
         else:
-            print("Loading safetensors")
+            #print("Loading safetensors")
             ckpt = load_file(model_path, 'cpu')
 
         if low_cpu_mem_usage:
             with init_empty_weights():
                 config = Phi3Config.from_pretrained(model_name)
                 model = cls(config)
-        
-            model.load_state_dict(ckpt, assign=True)
-            model = model.to(dtype)
+            
+            if quantization_config:
+                model = quantize_bnb(model, ckpt, quantization_config=quantization_config, pre_quantized=False)
+                if getattr(quantization_config, 'load_in_4bit', None):
+                    model.offloadable = False
+                model.quantization_config = quantization_config
+            else:
+                model.load_state_dict(ckpt, assign=True)
         else:
+            if quantization_config:
+                raise ValueError('Quantization not supported for `low_cpu_mem_usage=False`.')
+            
             config = Phi3Config.from_pretrained(model_name)
             model = cls(config)
             model.load_state_dict(ckpt)
-            model = model.to(dtype)
         
+        model = model.to(dtype)
         del ckpt
         torch.cuda.empty_cache()
         gc.collect()

--- a/OmniGen/pipeline.py
+++ b/OmniGen/pipeline.py
@@ -88,7 +88,7 @@ class OmniGenPipeline:
         if device is None:
             device = best_available_device()
 
-        model = OmniGen.from_pretrained(model_name, dtype=torch.bfloat16, device=device, low_cpu_mem_usage=low_cpu_mem_usage)
+        model = OmniGen.from_pretrained(model_name, dtype=torch.bfloat16, low_cpu_mem_usage=low_cpu_mem_usage)
         processor = OmniGenProcessor.from_pretrained(model_name)
 
         if vae_path is None:

--- a/OmniGen/pipeline.py
+++ b/OmniGen/pipeline.py
@@ -41,6 +41,15 @@ EXAMPLE_DOC_STRING = """
         ```
 """
 
+def best_available_device():
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        logger.info("Don't detect any available GPUs, using CPU instead, this may take long time to generate image!!!")
+        device = torch.device("cpu")
+    return device
 
 class OmniGenPipeline:
     def __init__(
@@ -55,14 +64,10 @@ class OmniGenPipeline:
         self.processor = processor
         self.device = device
 
-        if device is None:
-            if torch.cuda.is_available():
-                self.device = torch.device("cuda")
-            elif torch.backends.mps.is_available():
-                self.device = torch.device("mps")
-            else:
-                logger.info("Don't detect any available GPUs, using CPU instead, this may take long time to generate image!!!")
-                self.device = torch.device("cpu")
+        if self.device is None:
+            self.device = best_available_device()
+        elif isinstance(self.device, str):
+            self.device = torch.device(self.device)
 
         # self.model.to(torch.bfloat16)
         self.model.eval()
@@ -71,7 +76,7 @@ class OmniGenPipeline:
         self.model_cpu_offload = False
 
     @classmethod
-    def from_pretrained(cls, model_name, vae_path: str=None):
+    def from_pretrained(cls, model_name, vae_path: str=None, device=None, low_cpu_mem_usage=True):
         if not os.path.exists(model_name) or (not os.path.exists(os.path.join(model_name, 'model.safetensors')) and model_name == "Shitao/OmniGen-v1"):
             logger.info("Model not found, downloading...")
             cache_folder = os.getenv('HF_HUB_CACHE')
@@ -79,18 +84,23 @@ class OmniGenPipeline:
                                            cache_dir=cache_folder,
                                            ignore_patterns=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5', 'model.pt'])
             logger.info(f"Downloaded model to {model_name}")
-        model = OmniGen.from_pretrained(model_name)
+        
+        if device is None:
+            device = best_available_device()
+
+        model = OmniGen.from_pretrained(model_name, dtype=torch.bfloat16, device=device, low_cpu_mem_usage=low_cpu_mem_usage)
         processor = OmniGenProcessor.from_pretrained(model_name)
 
-        if os.path.exists(os.path.join(model_name, "vae")):
-            vae = AutoencoderKL.from_pretrained(os.path.join(model_name, "vae"))
-        elif vae_path is not None:
-            vae = AutoencoderKL.from_pretrained(vae_path).to(device)
-        else:
+        if vae_path is None:
+            vae_path = os.path.join(model_name, "vae")
+        
+        if not os.path.exists(vae_path):
             logger.info(f"No VAE found in {model_name}, downloading stabilityai/sdxl-vae from HF")
-            vae = AutoencoderKL.from_pretrained("stabilityai/sdxl-vae").to(device)
+            vae_path = "stabilityai/sdxl-vae"
+            
+        vae = AutoencoderKL.from_pretrained(vae_path).to(device)
 
-        return cls(vae, model, processor)
+        return cls(vae, model, processor, device)
     
     def merge_lora(self, lora_path: str):
         model = PeftModel.from_pretrained(self.model, lora_path)

--- a/OmniGen/pipeline.py
+++ b/OmniGen/pipeline.py
@@ -1,6 +1,6 @@
 import os
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, Literal
 import gc
 
 from PIL import Image
@@ -17,6 +17,7 @@ from diffusers.utils import (
     scale_lora_layers,
     unscale_lora_layers,
 )
+from transformers import BitsAndBytesConfig
 from safetensors.torch import load_file
 
 from OmniGen import OmniGen, OmniGenProcessor, OmniGenScheduler
@@ -76,7 +77,7 @@ class OmniGenPipeline:
         self.model_cpu_offload = False
 
     @classmethod
-    def from_pretrained(cls, model_name, vae_path: str=None, device=None, low_cpu_mem_usage=True):
+    def from_pretrained(cls, model_name, vae_path: str=None, device=None, quantization_config:Literal['bnb_4bit','bnb_8bit']|BitsAndBytesConfig=None, low_cpu_mem_usage=True):
         if not os.path.exists(model_name) or (not os.path.exists(os.path.join(model_name, 'model.safetensors')) and model_name == "Shitao/OmniGen-v1"):
             logger.info("Model not found, downloading...")
             cache_folder = os.getenv('HF_HUB_CACHE')
@@ -87,8 +88,16 @@ class OmniGenPipeline:
         
         if device is None:
             device = best_available_device()
-
-        model = OmniGen.from_pretrained(model_name, dtype=torch.bfloat16, low_cpu_mem_usage=low_cpu_mem_usage)
+        
+        if isinstance(quantization_config, str):
+            if quantization_config == 'bnb_4bit':
+                quantization_config = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_compute_dtype=torch.float32, bnb_4bit_quant_type='nf4', bnb_4bit_use_double_quant=False)
+            elif quantization_config == 'bnb_8bit':
+                quantization_config = BitsAndBytesConfig(load_in_8bit=True)
+            else:
+                raise NotImplementedError(f'Unknown `quantization_config` {quantization_config!r}')
+        
+        model = OmniGen.from_pretrained(model_name, dtype=torch.bfloat16, quantization_config=quantization_config, low_cpu_mem_usage=low_cpu_mem_usage)
         processor = OmniGenProcessor.from_pretrained(model_name)
 
         if vae_path is None:
@@ -98,7 +107,7 @@ class OmniGenPipeline:
             logger.info(f"No VAE found in {model_name}, downloading stabilityai/sdxl-vae from HF")
             vae_path = "stabilityai/sdxl-vae"
             
-        vae = AutoencoderKL.from_pretrained(vae_path).to(device)
+        vae = AutoencoderKL.from_pretrained(vae_path)
 
         return cls(vae, model, processor, device)
     
@@ -131,7 +140,8 @@ class OmniGenPipeline:
 
     def enable_model_cpu_offload(self):
         self.model_cpu_offload = True
-        self.model.to("cpu")
+        if self.model.offloadable:
+            self.model.to("cpu")
         self.vae.to("cpu")
         torch.cuda.empty_cache()  # Clear VRAM
         gc.collect()  # Run garbage collection to free system RAM
@@ -221,6 +231,7 @@ class OmniGenPipeline:
         if max_input_image_size != self.processor.max_image_size:
             self.processor = OmniGenProcessor(self.processor.text_tokenizer, max_image_size=max_input_image_size)
         self.model.to(dtype)
+        #self.vae.to(dtype) # Uncomment this line to allow bfloat16 VAE
         if offload_model:
             self.enable_model_cpu_offload()
         else:
@@ -250,12 +261,12 @@ class OmniGenPipeline:
             for temp_pixel_values in input_data['input_pixel_values']:
                 temp_input_latents = []
                 for img in temp_pixel_values:
-                    img = self.vae_encode(img.to(self.device), dtype)
+                    img = self.vae_encode(img.to(self.vae.device, self.vae.dtype), dtype)
                     temp_input_latents.append(img)
                 input_img_latents.append(temp_input_latents)
         else:
             for img in input_data['input_pixel_values']:
-                img = self.vae_encode(img.to(self.device), dtype)
+                img = self.vae_encode(img.to(self.vae.device, self.vae.dtype), dtype)
                 input_img_latents.append(img)
         if input_images is not None and self.model_cpu_offload:
             self.vae.to('cpu')
@@ -279,7 +290,7 @@ class OmniGenPipeline:
         else:
             func = self.model.forward_with_cfg
 
-        if self.model_cpu_offload:
+        if self.model_cpu_offload and self.model.offloadable:
             for name, param in self.model.named_parameters():
                 if 'layers' in name and 'layers.0' not in name:
                     param.data = param.data.cpu()
@@ -294,13 +305,13 @@ class OmniGenPipeline:
         samples = scheduler(latents, func, model_kwargs, use_kv_cache=use_kv_cache, offload_kv_cache=offload_kv_cache)
         samples = samples.chunk((1+num_cfg), dim=0)[0]
 
-        if self.model_cpu_offload:
+        if self.model_cpu_offload and self.model.offloadable:
             self.model.to('cpu')
             torch.cuda.empty_cache()  
             gc.collect()  
 
         self.vae.to(self.device)
-        samples = samples.to(torch.float32)
+        samples = samples.to(self.vae.dtype)
         if self.vae.config.shift_factor is not None:
             samples = samples / self.vae.config.scaling_factor + self.vae.config.shift_factor
         else:

--- a/OmniGen/scheduler.py
+++ b/OmniGen/scheduler.py
@@ -38,8 +38,8 @@ class OmniGenCache(DynamicCache):
                 prev_layer_idx = -1
             else:
                 prev_layer_idx = (layer_idx - 1) % len(self)
-            self.key_cache[prev_layer_idx] = self.key_cache[prev_layer_idx].to("cpu", non_blocking=True)
-            self.value_cache[prev_layer_idx] = self.value_cache[prev_layer_idx].to("cpu", non_blocking=True)
+            self.key_cache[prev_layer_idx] = self.key_cache[prev_layer_idx].to("cpu")
+            self.value_cache[prev_layer_idx] = self.value_cache[prev_layer_idx].to("cpu")
 
 
     def __getitem__(self, layer_idx: int) -> List[Tuple[torch.Tensor]]:
@@ -50,9 +50,9 @@ class OmniGenCache(DynamicCache):
                 torch.cuda.current_stream().synchronize()
                 self.evict_previous_layer(layer_idx)
                 # Load current layer cache to its original device if not already there
-                original_device = self.original_device[layer_idx]
+                #original_device = self.original_device[layer_idx]
                 # self.prefetch_stream.synchronize(original_device)
-                torch.cuda.synchronize(self.prefetch_stream)
+                self.prefetch_stream.synchronize()
                 key_tensor = self.key_cache[layer_idx]
                 value_tensor = self.value_cache[layer_idx]
                 

--- a/OmniGen/transformer.py
+++ b/OmniGen/transformer.py
@@ -42,7 +42,7 @@ class Phi3Transformer(Phi3Model):
         for name, param in self.layers[prev_layer_idx].named_parameters():
             param.data = param.data.to("cpu", non_blocking=True)
             
-    def get_offlaod_layer(self, layer_idx: int, device: torch.device):
+    def get_offload_layer(self, layer_idx: int, device: torch.device):
         # init stream
         if not hasattr(self, "prefetch_stream"):
             self.prefetch_stream = torch.cuda.Stream()
@@ -153,7 +153,7 @@ class Phi3Transformer(Phi3Model):
                 )
             else:
                 if offload_model and not self.training:
-                    self.get_offlaod_layer(layer_idx, device=inputs_embeds.device)
+                    self.get_offload_layer(layer_idx, device=inputs_embeds.device)
                 layer_outputs = decoder_layer(
                     hidden_states,
                     attention_mask=attention_mask,

--- a/OmniGen/transformer.py
+++ b/OmniGen/transformer.py
@@ -33,14 +33,12 @@ class Phi3Transformer(Phi3Model):
         "Starts prefetching the next layer cache"
         with torch.cuda.stream(self.prefetch_stream):
             # Prefetch next layer tensors to GPU
-            for name, param in self.layers[layer_idx].named_parameters():
-                param.data = param.data.to(device, non_blocking=True)
+            self.layers[layer_idx] = self.layers[layer_idx].to(device, non_blocking=True)
 
     def evict_previous_layer(self, layer_idx: int):
         "Moves the previous layer cache to the CPU"
         prev_layer_idx = layer_idx - 1
-        for name, param in self.layers[prev_layer_idx].named_parameters():
-            param.data = param.data.to("cpu", non_blocking=True)
+        self.layers[prev_layer_idx] = self.layers[prev_layer_idx].to("cpu")
             
     def get_offload_layer(self, layer_idx: int, device: torch.device):
         # init stream
@@ -48,11 +46,14 @@ class Phi3Transformer(Phi3Model):
             self.prefetch_stream = torch.cuda.Stream()
 
         # delete previous layer
-        torch.cuda.current_stream().synchronize()
-        self.evict_previous_layer(layer_idx)
+        # main stream sync shouldn't be necessary since all computation on iter i-1 is finished by iter i
+        # torch.cuda.current_stream().synchronize()
+        # avoid extra eviction of last layer
+        if layer_idx > 0:
+            self.evict_previous_layer(layer_idx)
         
         # make sure the current layer is ready
-        torch.cuda.synchronize(self.prefetch_stream)
+        self.prefetch_stream.synchronize()
 
         # load next layer
         self.prefetch_layer((layer_idx + 1) % len(self.layers), device)
@@ -133,10 +134,9 @@ class Phi3Transformer(Phi3Model):
         all_self_attns = () if output_attentions else None
         next_decoder_cache = None
 
-        layer_idx = -1
-        for decoder_layer in self.layers:
-            layer_idx += 1
-
+        for layer_idx in range(len(self.layers)):
+            # direct indexing since offloading may mutate self.layers during iteration 
+            decoder_layer = self.layers[layer_idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/OmniGen/transformer.py
+++ b/OmniGen/transformer.py
@@ -33,12 +33,14 @@ class Phi3Transformer(Phi3Model):
         "Starts prefetching the next layer cache"
         with torch.cuda.stream(self.prefetch_stream):
             # Prefetch next layer tensors to GPU
-            self.layers[layer_idx] = self.layers[layer_idx].to(device, non_blocking=True)
+            for name, param in self.layers[layer_idx].named_parameters():
+                param.data = param.data.to(device, non_blocking=True)
 
     def evict_previous_layer(self, layer_idx: int):
         "Moves the previous layer cache to the CPU"
         prev_layer_idx = layer_idx - 1
-        self.layers[prev_layer_idx] = self.layers[prev_layer_idx].to("cpu")
+        for name, param in self.layers[prev_layer_idx].named_parameters():
+            param.data = param.data.to("cpu")
             
     def get_offload_layer(self, layer_idx: int, device: torch.device):
         # init stream

--- a/app.py
+++ b/app.py
@@ -5,12 +5,8 @@ import argparse
 import random
 import spaces
 
-
 from OmniGen import OmniGenPipeline
 
-pipe = OmniGenPipeline.from_pretrained(
-    "Shitao/OmniGen-v1"
-)
 
 @spaces.GPU(duration=180)
 def generate_image(text, img1, img2, img3, height, width, guidance_scale, img_guidance_scale, inference_steps, seed, separate_cfg_infer, offload_model,
@@ -370,6 +366,8 @@ with gr.Blocks() as demo:
 
         with gr.Column():
             with gr.Column():
+                # quantization = gr.Radio(["4bit (NF4)", "8bit", "None (bf16)"], label="bitsandbytes quantization", value="4bit (NF4)")
+                # quantization.input(change_quantization, inputs=quantization, trigger_mode="once", concurrency_limit=1)
                 # output image
                 output_image = gr.Image(label="Output Image")
                 save_images = gr.Checkbox(label="Save generated images", value=False)
@@ -425,7 +423,21 @@ with gr.Blocks() as demo:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run the OmniGen')
     parser.add_argument('--share', action='store_true', help='Share the Gradio app')
+    parser.add_argument('-b', '--nbits', choices=['4','8'], help='bitsandbytes quantization n-bits')
     args = parser.parse_args()
 
+    if args.nbits == '4':
+        quantization_config = 'bnb_4bit'
+    elif args.nbits == '8':
+        quantization_config = 'bnb_8bit'
+    else:
+        quantization_config = None
+    
+    pipe = OmniGenPipeline.from_pretrained(
+        "Shitao/OmniGen-v1",
+        quantization_config = quantization_config,
+        low_cpu_mem_usage=True,
+    )
+    
     # launch
     demo.launch(share=args.share)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pillow==10.2.0
 peft==0.13.2
 diffusers==0.30.3
 timm==0.9.16
+bitsandbytes==0.44.1


### PR DESCRIPTION
## Changes
- Adds a `quantization_config` arg to `from_pretrained` for both `OmniGenPipeline` and `OmniGen`. 
- `OmniGen` expects a `transformers.BitsAndBytesConfig` while `OmniGenPipeline` can also accept a string alias ('bnb_4bit' or 'bnb_8bit')
- Adds a new requirement `bitsandbytes==0.44.1` 

### Usage
```python
quant_method = 'bnb_4bit' # or 'bnb_8bit'
pipe = OmniGenPipeline.from_pretrained("Shitao/OmniGen-v1", quantization_config=quant_method, low_cpu_mem_usage=True)
```
For use with `app.py` you can pass a cli arg `--nbits` or `-b`
```bash
python app.py --nbits 4
```
Ideally, this would be a gradio radio button component or something, but that's a task for another day.

## Results

Following a similar format to the [Different inference settings table](https://github.com/VectorSpaceLab/OmniGen/blob/main/docs/inference.md#requiremented-resources).

For 4bit-nf4 quantized model on RTX 3090 GPU(24G):
| Settings     |  Only Text | Text + Single Image |  Text + Two Images    |
|:-------------|:----------:|:-------------------:|:---------------------:|
| use_kv_cache=False                                              | 6.8G, 1m16s  | 7.2G, 3m30s   | 7.7G, 5m47s   |
| use_kv_cache=True                                               | 9.9G, 1m14s  | 20.4G†, 8m5s  | OOM (36.7G†, >1h10m)  |
| use_kv_cache,offload_kv_cache                                   | 6.8G, 1m16s  | 7.2G, 2m49s   | 8.4G, 4m3s  |
| use_kv_cache,offload_kv_cache,separate_cfg_infer                | 6.8G, 1m20s  | 7.0G, 2m31s   | 7.4G, 3m31s  |
| use_kv_cache,offload_kv_cache,offload_model*                    | 5.0G, 1m35s  | 6.0G, 3m7s    | 8.0G, 4m21s  |
| use_kv_cache,offload_kv_cache,separate_cfg_infer,offload_model* | 5.0G, 1m58s  | 5.3G, 3m29s   | 5.6G, 4m19s |

* † - memory_reserved > 24gb, RAM spillover
* \* - only VAE offload. Model loaded in 4bit cannot be offloaded.  

### Testing setup
- Timings are reported on the first 3 examples from the [inference.ipynb](https://github.com/VectorSpaceLab/OmniGen/blob/main/inference.ipynb) notebook.
  - For "Only Text", just the first prompt is used.
- vRAM is what's reported by `max_memory_allocated()`, `max_memory_reserved()` was typically ~3GB higher.

### Image Comparisons

```python
prompt = "A vintage camera placed on the ground, ejecting a swirling cloud of Polaroid-style photographs into the air. The photos, showing landscapes, wildlife, and travel scenes, seem to defy gravity, floating upward in a vortex of motion. The camera emits a glowing, smoky light from within, enhancing the magical, surreal atmosphere. The dark background contrasts with the illuminated photos and camera, creating a dreamlike, nostalgic scene filled with vibrant colors and dynamic movement. Scattered photos are visible on the ground, further contributing to the idea of an explosion of captured memories."
pipe(prompt=prompt, height=1024, width=1024, guidance_scale=2.5,  seed=0, ...)
```

![text_only_1111_4bit_bf16](https://github.com/user-attachments/assets/f7c4309f-6a09-41b7-952e-dcc888f83959)


```python
prompt="The woman in <img><|image_1|></img> waves her hand happily in the crowd"
input_images=["./imgs/test_cases/zhang.png"]
pipe(prompt=prompt, input_images=input_images, height=1024, width=1024, guidance_scale=2.5, img_guidance_scale=1.8,  seed=42, ...)
```

![single_img_1111_4bit_bf16](https://github.com/user-attachments/assets/4a2213ef-6a97-4658-bb7e-7cffb94156a7)


```python
prompt = "Two woman are raising fried chicken legs in a bar. A woman is <img><|image_1|></img>. Another woman is <img><|image_2|></img>."
input_images = ["./imgs/test_cases/mckenna.jpg", "./imgs/test_cases/Amanda.jpg"]
pipe(prompt=prompt, input_images=input_images, height=1024, width=1024,guidance_scale=2.5, img_guidance_scale=1.8, max_input_image_size=1024, seed=168, ...)
```

![double_img_1111_4bit_bf16](https://github.com/user-attachments/assets/5d42f64e-1bfc-4dd7-b98c-72f39589d484)


### 8-bit
I didn't spend much time testing 8-bit, but without cache offloading -> OOM. Here's a couple samples otherwise. 

For bnb 8bit quantized model on RTX 3090 GPU(24G):
| Settings     |  Only Text | Text + Single Image |  Text + Two Images    |
|:-------------|:----------:|:-------------------:|:---------------------:|
| use_kv_cache,offload_kv_cache,separate_cfg_infer                | 8.6G, 1m17s  | 8.8G, 2m39s   | 9.2G, 3m42s  |
| use_kv_cache,offload_kv_cache,separate_cfg_infer,offload_model  | 8.2G, 2m28s  | 8.4G, 4m17s   | 8.8G, 5m10s |

**Images**

Same prompts + settings as above, all with 8-bit quantization.

![to_si_di_1110_8bit](https://github.com/user-attachments/assets/dd36fb6d-10db-4bf4-a8bb-59faadc2070d)


### Additional Considerations
- I briefly experimented with casting the VAE to bfloat16. The outputs appeared identical from my tests. There are numerical stability issues that can arise from reduced precision without careful handling, however. [See diffusers](https://github.com/huggingface/diffusers/blob/ad5ecd1251472dbc69da1268671d41bc2d8c1caa/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py#L747). That said, it can save 1-2GB if you're willing to risk black outputs.
- Tried `bnb_4bit_quant_type='fp4'` - same vRAM, same timings, worse quality images. 
- Tried `bnb_4bit_compute_dtype=torch.bfloat16` - very poor quality images. 

---
_This is the third of 3 PRs I'm issuing to improve performance/fix errors. I've tried to keep each incremental change as small in scope as possible._