### PR TITLE
Replicate Update: Support Multiple Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ local.ipynb
 convert_to_safetensor.py
 test_memory_time.py
 test.py
+
+# cog
+.cog/

--- a/OmniGen/pipeline.py
+++ b/OmniGen/pipeline.py
@@ -193,6 +193,8 @@ class OmniGenPipeline:
                 data type for the model
             output_type (`str`, *optional*, defaults to "pil"):
                 The type of the output image, which can be "pt" or "pil"
+            num_images (`int`, *optional*, defaults to 1):
+                The number of images to generate
         Examples:
 
         Returns:

--- a/OmniGen/pipeline.py
+++ b/OmniGen/pipeline.py
@@ -154,7 +154,6 @@ class OmniGenPipeline:
         dtype: torch.dtype = torch.bfloat16,
         seed: int = None,
         output_type: str = "pil",
-        num_images: int = 1,
         ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -193,8 +192,6 @@ class OmniGenPipeline:
                 data type for the model
             output_type (`str`, *optional*, defaults to "pil"):
                 The type of the output image, which can be "pt" or "pil"
-            num_images (`int`, *optional*, defaults to 1):
-                The number of images to generate
         Examples:
 
         Returns:

--- a/OmniGen/pipeline.py
+++ b/OmniGen/pipeline.py
@@ -154,6 +154,7 @@ class OmniGenPipeline:
         dtype: torch.dtype = torch.bfloat16,
         seed: int = None,
         output_type: str = "pil",
+        num_images: int = 1,
         ):
         r"""
         Function invoked when calling the pipeline for generation.

--- a/predict.py
+++ b/predict.py
@@ -122,6 +122,7 @@ class Predictor(BasePredictor):
                 use_input_image_size_as_output=use_input_image_size_as_output,
                 seed=seed,
                 max_input_image_size=max_input_image_size,
+                num_images=num_images,
             )
             img = output[0]
             out_path = f"/tmp/out_{i}.png"

--- a/predict.py
+++ b/predict.py
@@ -97,7 +97,7 @@ class Predictor(BasePredictor):
             description="Automatically adjust the output image size to be same as input image size. For editing and controlnet task, it can make sure the output image has the same size as input image leading to better performance",
             default=False,
         ),
-        num_images: int = Input(description="The number of images to generate for the given inputs", default=1, ge=1, le=10),
+        num_images_per_prompt: int = Input(description="The number of images to generate for the given inputs", default=1, ge=1, le=10),
     ) -> List[Path]:
         """Run a single prediction on the model"""
         if seed is None:
@@ -106,7 +106,7 @@ class Predictor(BasePredictor):
 
         input_images = [str(img) for img in [img1, img2, img3] if img is not None]
         output = []
-        for i in range(num_images):
+        for i in range(num_images_per_prompt):
             output = self.pipe(
                 prompt=prompt,
                 input_images=None if len(input_images) == 0 else input_images,
@@ -121,8 +121,7 @@ class Predictor(BasePredictor):
                 offload_model=offload_model,
                 use_input_image_size_as_output=use_input_image_size_as_output,
                 seed=seed,
-                max_input_image_size=max_input_image_size,
-                num_images=num_images,
+                max_input_image_size=max_input_image_size
             )
             img = output[0]
             out_path = f"/tmp/out_{i}.png"

--- a/predict.py
+++ b/predict.py
@@ -105,7 +105,7 @@ class Predictor(BasePredictor):
         print(f"Using seed: {seed}")
 
         input_images = [str(img) for img in [img1, img2, img3] if img is not None]
-        output = []
+        outputs = []
         for i in range(num_images_per_prompt):
             output = self.pipe(
                 prompt=prompt,
@@ -126,5 +126,5 @@ class Predictor(BasePredictor):
             img = output[0]
             out_path = f"/tmp/out_{i}.png"
             img.save(out_path)
-            output.append(Path(out_path))
-        return output
+            outputs.append(Path(out_path))
+        return outputs


### PR DESCRIPTION
Hi there, I was keen on using replicate and generating multiple images in one go. I've made this PR to allow the usage of multiple images. 

- Add param 'num_images_per_prompt' to schema
- Return a list of Paths for each image
- Rename images to out_{iteration}.png

Follow up: 

Given more time, I'd probably look at updating OmnigenPipeline to do this too.

Sample Output Locally:

I cleaned the following output a touch (removed base64 output strings)

```text
curl http://localhost:5003/predictions -X POST --header "Content-Type: application/json" --data '{"input": {"prompt": "Create a scenic view of the mountains", "num_images_per_prompt": 3, "width": 128, "height": 128}}'
{"input":{"prompt":"Create a scenic view of the mountains","img1":null,"img2":null,"img3":null,"width":128,"height":128,"inference_steps":50,"guidance_scale":2.5,"img_guidance_scale":1.6,"seed":null,"max_input_image_size":1024,"separate_cfg_infer":true,"offload_model":false,"use_input_image_size_as_output":false,"num_images_per_prompt":3},"output":["data:image/png;base64,iV...=="],"id":null,"version":null,"created_at":null,"started_at":"2025-01-10T21:07:46.098716+00:00","completed_at":"2025-01-10T21:08:05.749434+00:00","logs":"Using seed: 1497\n  0%|          | 0/50 [00:00<?, ?it/s]\n  2%|▏         | 1/50 [00:00<00:32,  1.50it/s]\n  6%|▌         | 3/50 [00:00<00:10,  4.31it/s]\n 10%|█         | 5/50 [00:01<00:07,  6.11it/s]\n 12%|█▏        | 6/50 [00:01<00:06,  6.81it/s]\n 16%|█▌        | 8/50 [00:01<00:04,  8.64it/s]\n 20%|██        | 10/50 [00:01<00:04,  9.77it/s]\n 24%|██▍       | 12/50 [00:01<00:03, 10.39it/s]\n 28%|██▊       | 14/50 [00:02<00:04,  7.53it/s]\n 30%|███       | 15/50 [00:02<00:05,  6.92it/s]\n 32%|███▏      | 16/50 [00:02<00:05,  6.41it/s]\n 34%|███▍      | 17/50 [00:02<00:05,  5.95it/s]\n 36%|███▌      | 18/50 [00:02<00:04,  6.50it/s]\n 40%|████      | 20/50 [00:02<00:03,  8.13it/s]\n 44%|████▍     | 22/50 [00:03<00:02,  9.52it/s]\n 48%|████▊     | 24/50 [00:03<00:02, 10.42it/s]\n 52%|█████▏    | 26/50 [00:03<00:02, 11.16it/s]\n 56%|█████▌    | 28/50 [00:03<00:01, 11.77it/s]\n 60%|██████    | 30/50 [00:03<00:01, 12.04it/s]\n 64%|██████▍   | 32/50 [00:03<00:01, 12.54it/s]\n 68%|██████▊   | 34/50 [00:04<00:01, 10.11it/s]\n 72%|███████▏  | 36/50 [00:04<00:01, 10.20it/s]\n 76%|███████▌  | 38/50 [00:04<00:01, 10.90it/s]\n 80%|████████  | 40/50 [00:04<00:00, 11.49it/s]\n 84%|████████▍ | 42/50 [00:04<00:00, 11.99it/s]\n 88%|████████▊ | 44/50 [00:04<00:00, 12.21it/s]\n 92%|█████████▏| 46/50 [00:05<00:00, 12.34it/s]\n 96%|█████████▌| 48/50 [00:05<00:00, 12.51it/s]\n100%|██████████| 50/50 [00:05<00:00, 12.76it/s]\n100%|██████████| 50/50 [00:05<00:00,  9.34it/s]\n  0%|
 | 0/50 [00:00<?, ?it/s]\n  2%|▏         | 1/50 [00:00<00:07,  6.95it/s]\n  6%|▌         | 3/50 [00:00<00:04, 10.14it/s]\n 10%|█         | 5/50 [00:00<00:03, 11.41it/s]\n 14%|█▍        | 7/50 [00:00<00:03, 11.34it/s]\n 18%|█▊        | 9/50 [00:00<00:03, 11.87it/s]\n 22%|██▏       | 11/50 [00:00<00:03, 12.11it/s]\n 26%|██▌       | 13/50 [00:01<00:03, 12.32it/s]\n 30%|███       | 15/50 [00:01<00:02, 12.72it/s]\n 34%|███▍      | 17/50 [00:01<00:02, 12.86it/s]\n 38%|███▊      | 19/50 [00:01<00:02, 12.87it/s]\n 42%|████▏     | 21/50 [00:01<00:02, 13.13it/s]\n 46%|████▌     | 23/50 [00:01<00:02, 13.13it/s]\n 50%|█████     | 25/50 [00:02<00:01, 12.95it/s]\n 54%|█████▍    | 27/50 [00:02<00:01, 12.87it/s]\n 58%|█████▊    | 29/50 [00:02<00:01, 12.62it/s]\n 62%|██████▏   | 31/50 [00:02<00:01, 12.76it/s]\n 66%|██████▌   | 33/50 [00:02<00:01,  8.84it/s]\n 70%|███████   | 35/50 [00:03<00:02,  7.34it/s]\n 74%|███████▍  | 37/50 [00:03<00:01,  8.56it/s]\n 78%|███████▊  | 39/50 [00:03<00:01,  9.39it/s]\n 82%|████████▏ | 41/50 [00:03<00:00,  9.08it/s]\n 86%|████████▌ | 43/50 [00:04<00:00,  8.77it/s]\n 90%|█████████ | 45/50 [00:04<00:00,  9.61it/s]\n 94%|█████████▍| 47/50 [00:04<00:00, 10.49it/s]\n 98%|█████████▊| 49/50 [00:04<00:00,  8.50it/s]\n100%|██████████| 50/50 [00:04<00:00, 10.44it/s]\n  0%|          | 0/50 [00:00<?, ?it/s]\n  2%|▏         | 1/50 [00:00<00:06,  7.40it/s]\n  6%|▌         | 3/50 [00:00<00:04,  9.76it/s]\n 10%|█         | 5/50 [00:00<00:04, 10.69it/s]\n 14%|█▍        | 7/50 [00:00<00:03, 11.71it/s]\n 18%|█▊        | 9/50 [00:00<00:03, 12.17it/s]\n 22%|██▏       | 11/50 [00:00<00:03, 11.13it/s]\n 26%|██▌       | 13/50 [00:01<00:03, 11.90it/s]\n 30%|███       | 15/50 [00:01<00:03, 10.83it/s]\n 34%|███▍      | 17/50 [00:01<00:03, 10.54it/s]\n 38%|███▊      | 19/50 [00:01<00:02, 10.86it/s]\n 42%|████▏     | 21/50 [00:01<00:02, 11.55it/s]\n 46%|████▌     | 23/50 [00:02<00:02, 12.01it/s]\n 50%|█████     | 25/50 [00:02<00:02, 12.43it/s]\n 54%|█████▍    | 27/50 [00:02<00:01, 12.20it/s]\n 58%|█████▊    | 29/50 [00:02<00:01, 11.79it/s]\n 62%|██████▏   | 31/50 [00:02<00:01, 11.05it/s]\n 66%|██████▌   | 33/50 [00:02<00:01, 10.22it/s]\n 70%|███████   | 35/50 [00:03<00:01,  9.97it/s]\n 74%|███████▍  | 37/50 [00:03<00:01, 10.55it/s]\n 78%|███████▊  | 39/50 [00:03<00:00, 11.35it/s]\n 82%|████████▏ | 41/50 [00:03<00:00, 11.83it/s]\n 86%|████████▌ | 43/50 [00:03<00:00, 11.37it/s]\n 90%|█████████ | 45/50 [00:03<00:00, 11.78it/s]\n 94%|█████████▍| 47/50 [00:04<00:00, 12.15it/s]\n 98%|█████████▊| 49/50 [00:04<00:00, 12.43it/s]\n100%|██████████| 50/50 [00:04<00:00, 11.43it/s]\n","error":null,"status":"succeeded","metrics":{"predict_time":19.650718}}
```

```text
Using seed: 1497
  0%|          | 0/50 [00:00<?, ?it/s]
  2%|▏         | 1/50 [00:00<00:32,  1.50it/s]
  6%|▌         | 3/50 [00:00<00:10,  4.31it/s]
 10%|█         | 5/50 [00:01<00:07,  6.11it/s]
 12%|█▏        | 6/50 [00:01<00:06,  6.81it/s]
 16%|█▌        | 8/50 [00:01<00:04,  8.64it/s]
 20%|██        | 10/50 [00:01<00:04,  9.77it/s]
 24%|██▍       | 12/50 [00:01<00:03, 10.39it/s]
 28%|██▊       | 14/50 [00:02<00:04,  7.53it/s]
 30%|███       | 15/50 [00:02<00:05,  6.92it/s]
 32%|███▏      | 16/50 [00:02<00:05,  6.41it/s]
 34%|███▍      | 17/50 [00:02<00:05,  5.95it/s]
 36%|███▌      | 18/50 [00:02<00:04,  6.50it/s]
 40%|████      | 20/50 [00:02<00:03,  8.13it/s]
 44%|████▍     | 22/50 [00:03<00:02,  9.52it/s]
 48%|████▊     | 24/50 [00:03<00:02, 10.42it/s]
 52%|█████▏    | 26/50 [00:03<00:02, 11.16it/s]
 56%|█████▌    | 28/50 [00:03<00:01, 11.77it/s]
 60%|██████    | 30/50 [00:03<00:01, 12.04it/s]
 64%|██████▍   | 32/50 [00:03<00:01, 12.54it/s]
 68%|██████▊   | 34/50 [00:04<00:01, 10.11it/s]
 72%|███████▏  | 36/50 [00:04<00:01, 10.20it/s]
 76%|███████▌  | 38/50 [00:04<00:01, 10.90it/s]
 80%|████████  | 40/50 [00:04<00:00, 11.49it/s]
 84%|████████▍ | 42/50 [00:04<00:00, 11.99it/s]
 88%|████████▊ | 44/50 [00:04<00:00, 12.21it/s]
 92%|█████████▏| 46/50 [00:05<00:00, 12.34it/s]
 96%|█████████▌| 48/50 [00:05<00:00, 12.51it/s]
100%|██████████| 50/50 [00:05<00:00, 12.76it/s]
100%|██████████| 50/50 [00:05<00:00,  9.34it/s]
  0%|          | 0/50 [00:00<?, ?it/s]
  2%|▏         | 1/50 [00:00<00:07,  6.95it/s]
  6%|▌         | 3/50 [00:00<00:04, 10.14it/s]
 10%|█         | 5/50 [00:00<00:03, 11.41it/s]
 14%|█▍        | 7/50 [00:00<00:03, 11.34it/s]
 18%|█▊        | 9/50 [00:00<00:03, 11.87it/s]
 22%|██▏       | 11/50 [00:00<00:03, 12.11it/s]
 26%|██▌       | 13/50 [00:01<00:03, 12.32it/s]
 30%|███       | 15/50 [00:01<00:02, 12.72it/s]
 34%|███▍      | 17/50 [00:01<00:02, 12.86it/s]
 38%|███▊      | 19/50 [00:01<00:02, 12.87it/s]
 42%|████▏     | 21/50 [00:01<00:02, 13.13it/s]
 46%|████▌     | 23/50 [00:01<00:02, 13.13it/s]
 50%|█████     | 25/50 [00:02<00:01, 12.95it/s]
 54%|█████▍    | 27/50 [00:02<00:01, 12.87it/s]
 58%|█████▊    | 29/50 [00:02<00:01, 12.62it/s]
 62%|██████▏   | 31/50 [00:02<00:01, 12.76it/s]
 66%|██████▌   | 33/50 [00:02<00:01,  8.84it/s]
 70%|███████   | 35/50 [00:03<00:02,  7.34it/s]
 74%|███████▍  | 37/50 [00:03<00:01,  8.56it/s]
 78%|███████▊  | 39/50 [00:03<00:01,  9.39it/s]
 82%|████████▏ | 41/50 [00:03<00:00,  9.08it/s]
 86%|████████▌ | 43/50 [00:04<00:00,  8.77it/s]
 90%|█████████ | 45/50 [00:04<00:00,  9.61it/s]
 94%|█████████▍| 47/50 [00:04<00:00, 10.49it/s]
 98%|█████████▊| 49/50 [00:04<00:00,  8.50it/s]
100%|██████████| 50/50 [00:04<00:00, 10.44it/s]
  0%|          | 0/50 [00:00<?, ?it/s]
  2%|▏         | 1/50 [00:00<00:06,  7.40it/s]
  6%|▌         | 3/50 [00:00<00:04,  9.76it/s]
 10%|█         | 5/50 [00:00<00:04, 10.69it/s]
 14%|█▍        | 7/50 [00:00<00:03, 11.71it/s]
 18%|█▊        | 9/50 [00:00<00:03, 12.17it/s]
 22%|██▏       | 11/50 [00:00<00:03, 11.13it/s]
 26%|██▌       | 13/50 [00:01<00:03, 11.90it/s]
 30%|███       | 15/50 [00:01<00:03, 10.83it/s]
 34%|███▍      | 17/50 [00:01<00:03, 10.54it/s]
 38%|███▊      | 19/50 [00:01<00:02, 10.86it/s]
 42%|████▏     | 21/50 [00:01<00:02, 11.55it/s]
 46%|████▌     | 23/50 [00:02<00:02, 12.01it/s]
 50%|█████     | 25/50 [00:02<00:02, 12.43it/s]
 54%|█████▍    | 27/50 [00:02<00:01, 12.20it/s]
 58%|█████▊    | 29/50 [00:02<00:01, 11.79it/s]
 62%|██████▏   | 31/50 [00:02<00:01, 11.05it/s]
 66%|██████▌   | 33/50 [00:02<00:01, 10.22it/s]
 70%|███████   | 35/50 [00:03<00:01,  9.97it/s]
 74%|███████▍  | 37/50 [00:03<00:01, 10.55it/s]
 78%|███████▊  | 39/50 [00:03<00:00, 11.35it/s]
 82%|████████▏ | 41/50 [00:03<00:00, 11.83it/s]
 86%|████████▌ | 43/50 [00:03<00:00, 11.37it/s]
 90%|█████████ | 45/50 [00:03<00:00, 11.78it/s]
 94%|█████████▍| 47/50 [00:04<00:00, 12.15it/s]
 98%|█████████▊| 49/50 [00:04<00:00, 12.43it/s]
100%|██████████| 50/50 [00:04<00:00, 11.43it/s]
{"prediction_id": null, "logger": "cog.server.runner", "timestamp": "2025-01-10T21:08:05.749089Z", "severity": "INFO", "message": "prediction succeeded"}
```

